### PR TITLE
Performance of MovingMinMax0 is now slightly better.

### DIFF
--- a/deque.go
+++ b/deque.go
@@ -69,6 +69,7 @@ func (d *deque_IV) PopBack() *_IV {
 	return d.items[d.back]
 }
 
+
 func (d *deque_IV) PruneBack() {
 	d.size--
 	d.back--
@@ -108,55 +109,81 @@ type intfloatqueue struct {
 	nodes []*intfloatnode
 	head  uint
 	tail  uint
-	count uint
-	size  uint
+	mask  uint
 }
 
 func newintfloatqueue(size uint) *intfloatqueue {
 	size = nextPowerOfTwo(size + 1)
 	n := make([]*intfloatnode, size)
-	for i := uint(0); i < size; i++ {
+	for i:= range n {
 		n[i] = &intfloatnode{}
 	}
 	return &intfloatqueue{
 		nodes: n,
-		size:  size,
+		mask:  size - 1,
 	}
+}
+
+func (q *intfloatqueue) empty() bool {
+	return q.tail == q.head
+}
+
+func (q *intfloatqueue) nonempty() bool {
+	return q.tail != q.head
+}
+
+
+func (q *intfloatqueue) count() uint {
+	return (q.tail-q.head) & q.mask
 }
 
 func (q *intfloatqueue) push(index uint, value float32) {
 	q.nodes[q.tail].index = index
 	q.nodes[q.tail].value = value
-	q.tail = (q.tail + 1) & (q.size - 1)
-	q.count++
+	q.tail = (q.tail + 1) & q.mask
 }
 
 func (q *intfloatqueue) pop() *intfloatnode {
 	node := q.nodes[q.head]
-	q.head = (q.head + 1) & (q.size - 1)
-	q.count--
+	q.head = (q.head + 1) & q.mask
 	return node
 }
 
 func (q *intfloatqueue) tailnode() *intfloatnode {
-	return q.nodes[(q.tail+q.size-1)&(q.size-1)]
+	return q.nodes[(q.tail - 1) & q.mask]
+}
+
+func (q *intfloatqueue) tailvalue() float32 {
+	return q.nodes[(q.tail - 1) & q.mask].value
 }
 
 func (q *intfloatqueue) poptail() *intfloatnode {
-	q.tail = (q.tail + q.size - 1) & (q.size - 1)
+	q.tail = (q.tail - 1) & q.mask
 	node := q.nodes[q.tail]
-	q.count--
 	return node
 }
 
 func (q *intfloatqueue) prunetail() {
-	q.tail = (q.tail + q.size - 1) & (q.size - 1)
-	q.count--
+	q.tail = (q.tail - 1) & q.mask
+}
+
+func (q *intfloatqueue) prunehead() {
+	q.head = (q.head + 1) & q.mask
 }
 
 func (q *intfloatqueue) headnode() *intfloatnode {
 	return q.nodes[q.head]
 }
+
+func (q *intfloatqueue) headindex() uint {
+	return q.nodes[q.head].index
+}
+
+
+func (q *intfloatqueue) headvalue() float32 {
+	return q.nodes[q.head].value
+}
+
 
 type intfloatnode struct {
 	index uint

--- a/movingminmax_test.go
+++ b/movingminmax_test.go
@@ -149,14 +149,6 @@ func BenchmarkReference(b *testing.B) {
 	}
 }
 
-func BenchmarkMovingMinMax(b *testing.B) {
-	minmax := NewMovingMinMax(W)
-	for j := 0; j < b.N; j++ {
-		for i := range values {
-			minmax.Update(values[i])
-		}
-	}
-}
 
 func BenchmarkMovingMinMax0(b *testing.B) {
 	minmax := NewMovingMinMax0(W)
@@ -166,6 +158,16 @@ func BenchmarkMovingMinMax0(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkMovingMinMax(b *testing.B) {
+	minmax := NewMovingMinMax(W)
+	for j := 0; j < b.N; j++ {
+		for i := range values {
+			minmax.Update(values[i])
+		}
+	}
+}
+
 
 func BenchmarkMovingMin(b *testing.B) {
 	mmin := NewMovingMin(W)


### PR DESCRIPTION
I optimized MovingMinMax0, on my test machine, it is now consistently faster than MovingMinMax by a tiny amount (~3%) suggesting that we may have reached something close to the best you can do in pure Go (maybe?).

Note how computing the max, and the min separately costs a lot more than computing the min and max together!

```
 $ go test -bench=.
 PASS
 BenchmarkReference    50000         50037 ns/op
 BenchmarkMovingMinMax0   100000         25181 ns/op
 BenchmarkMovingMinMax    100000         26129 ns/op
 BenchmarkMovingMin   100000         18446 ns/op
 BenchmarkMovingMax   100000         17971 ns/op
 ok     _/home/dlemire/CVS/github/movingminmax  13.129s
```
